### PR TITLE
Iris/Oculus shader compilation fixes

### DIFF
--- a/src/main/kotlin/io/github/jedlimlx/supplemental_patches/shaders/MaterialGenerator.kt
+++ b/src/main/kotlin/io/github/jedlimlx/supplemental_patches/shaders/MaterialGenerator.kt
@@ -872,6 +872,11 @@ fun modifyGBuffers(directory: Path) {
                         "    flat in vec2 midCoord;"
             )
             .replace(
+                "flat out vec2 absMidCoordPos;",
+                "flat out vec2 absMidCoordPos;\n" +
+                        "    flat out vec2 midCoord;"
+            )
+            .replace(
                 "#include \"/lib/materials/materialHandling/blockEntityMaterials.glsl\"",
                 "#include \"/lib/materials/materialHandling/blockEntityMaterials.glsl\"\n" +
                 "\n" +

--- a/src/main/kotlin/io/github/jedlimlx/supplemental_patches/shaders/MaterialGenerator.kt
+++ b/src/main/kotlin/io/github/jedlimlx/supplemental_patches/shaders/MaterialGenerator.kt
@@ -450,8 +450,7 @@ fun generateVoxelsAndBlocklight(directory: Path) {
                             if (material.heldLighting && idx % material.blockSize == 0) {
                                 // Removing from their existing item ids
                                 material.allIds().forEach {
-                                    val tokens = it.split(":")
-                                    text = text.replace("${tokens[0]}:${tokens[1]}", "")
+                                    text = removeId(it, text)
                                 }
 
                                 // Adding to new materials
@@ -485,8 +484,7 @@ fun generateVoxelsAndBlocklight(directory: Path) {
                             if (material.heldLighting && idx % material.blockSize == 0) {
                                 // Removing from their existing item ids
                                 material.allIds().forEach {
-                                    val tokens = it.split(":")
-                                    text = text.replace("${tokens[0]}:${tokens[1]}", "")
+                                    text = removeId(it, text)
                                 }
 
                                 // Adding to new materials

--- a/src/main/kotlin/io/github/jedlimlx/supplemental_patches/shaders/Uniform.kt
+++ b/src/main/kotlin/io/github/jedlimlx/supplemental_patches/shaders/Uniform.kt
@@ -35,8 +35,10 @@ fun generateUniforms(directory: Path) {
             if (it.conditions.isNotEmpty()) {
                 append("$indent#if ${it.conditions.conditions()}\n")
                 append("${indent}uniform.${it.type}.${it.name} = ${it.code}\n")
-                append("$indent#else\n")
-                append("${indent}uniform.${it.type}.${it.name} = ${it.defaultValue}\n")
+                if (it.defaultValue != null) {
+                    append("$indent#else\n")
+                    append("${indent}uniform.${it.type}.${it.name} = ${it.defaultValue}\n")
+                }
                 append("$indent#endif\n")
             } else append("${indent}uniform.${it.type}.${it.name} = ${it.code}\n")
         }

--- a/src/main/resources/resourcepacks/builtin_shaders/assets/supplemental_patches/euphoria/atmospherics/fog/functions/doom_and_gloom_fog.glsl
+++ b/src/main/resources/resourcepacks/builtin_shaders/assets/supplemental_patches/euphoria/atmospherics/fog/functions/doom_and_gloom_fog.glsl
@@ -1,11 +1,15 @@
 void DoDoomAndGloomFog(inout vec3 color, float lViewPos) {
     #ifdef DO_DOOM_AND_GLOOM_FOG
         float fog = lViewPos * FOG_INTENSITY;
-    #else
-        float fog = lViewPos * FOG_INTENSITY * doomAndGloomFog;
-    #endif
-    fog *= fog;
-    fog = 1.0 - exp(-fog);
+        fog *= fog;
+        fog = 1.0 - exp(-fog);
 
-    color = mix(color, vec3(0.5, 0.5, 0.5), fog);
+        color = mix(color, vec3(0.5, 0.5, 0.5), fog);
+    #elif MOD_DOOM_AND_GLOOM
+        float fog = lViewPos * FOG_INTENSITY * doomAndGloomFog;
+        fog *= fog;
+        fog = 1.0 - exp(-fog);
+
+        color = mix(color, vec3(0.5, 0.5, 0.5), fog);
+    #endif
 }

--- a/src/main/resources/resourcepacks/builtin_shaders/assets/supplemental_patches/euphoria/atmospherics/fog/functions/sandstorm_fog.glsl
+++ b/src/main/resources/resourcepacks/builtin_shaders/assets/supplemental_patches/euphoria/atmospherics/fog/functions/sandstorm_fog.glsl
@@ -1,7 +1,9 @@
 void DoSandstormFog(inout vec3 color, float lViewPos) {
-    float fog = lViewPos * yungSandstormFactor;
-    fog = sqrt(fog) * YUNGS_SANDSTORM_FOG_INTENSITY;
-    fog = 1.0 - exp(-fog);
+    #ifdef MOD_YUNGSCAVEBIOMES
+        float fog = lViewPos * yungSandstormFactor;
+        fog = sqrt(fog) * YUNGS_SANDSTORM_FOG_INTENSITY;
+        fog = 1.0 - exp(-fog);
 
-    color = mix(color, vec3(0.8, 0.5, 0.1), fog);
+        color = mix(color, vec3(0.8, 0.5, 0.1), fog);
+    #endif
 }

--- a/src/main/resources/resourcepacks/builtin_shaders/assets/supplemental_patches/euphoria/atmospherics/sky/enderscape_nebula.glsl
+++ b/src/main/resources/resourcepacks/builtin_shaders/assets/supplemental_patches/euphoria/atmospherics/sky/enderscape_nebula.glsl
@@ -58,7 +58,7 @@ vec2 fbm3d_2d(vec3 x) {
     vec2 v = vec2(0.0);
     float a = 1.0;
 
-    #ifdef ES_NEBULA_DISTORATION_QUALITY == 1
+    #if defined ES_NEBULA_DISTORATION_QUALITY && ES_NEBULA_DISTORATION_QUALITY == 1
         int octaves = 3;
     #elif ES_NEBULA_DISTORTION_QUALITY == 2
         int octaves = 5;

--- a/src/main/resources/resourcepacks/builtin_shaders/assets/supplemental_patches/euphoria/terrain/galosphere/lumiere_composter.glsl
+++ b/src/main/resources/resourcepacks/builtin_shaders/assets/supplemental_patches/euphoria/terrain/galosphere/lumiere_composter.glsl
@@ -2,7 +2,7 @@ vec3 worldPos = playerPos + cameraPosition;
 vec3 fractPos = fract(worldPos.xyz);
 vec2 coordM = abs(fractPos.xz - 0.5);
 if (max(coordM.x, coordM.y) < 0.375 && NdotU > 0.9) {
-    #ifdef GLOWING_LUMIERE >= 1
+    #if defined GLOWING_LUMIERE && GLOWING_LUMIERE >= 1
         emission = 1.3 * pow2(color.r) + 3.8 * pow2(pow2(color.r));
     #endif
 


### PR DESCRIPTION
**Changes:**

`Uniform.kt`: No longer defines uniforms with no default value as null, as it is considered an unknown variable by Iris/Oculus

`MaterialGenerator.kt`: Add corresponding out declaration for midCoord to remove need for compatibility transformer there.
Fix failed ResourceLocation parse caused by generateVoxelsAndBlocklight breaking property files (didn't use the safe replacements that other methods use. As a result, it is a bit slower now, and could possibly benefit from the same optimizations added for the other methods, but it's probably fine for now.)

`doom_and_gloom_fog.glsl`, `sandstorm_fog.glsl`: Fixes #2 (reproducible by enabling Iris/Oculus debug mode, which does not remove unused functions)

`lumiere_composter.glsl`, `enderscape_nebula.glsl`: Fixes unexpected nonwhite token